### PR TITLE
Fix file re-upload bug

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -25,6 +25,7 @@ uploadArea.addEventListener('drop', (e) => {
 function handleFiles(e) {
   const file = e.target.files[0];
   if (file) handleFile(file);
+  e.target.value = '';
 }
 
 function handleFile(file) {
@@ -40,6 +41,7 @@ function handleFile(file) {
     }
   };
   reader.readAsText(file);
+  document.getElementById('file-input').value = '';
 }
 
 document.getElementById('apply-filters').addEventListener('click', applyFilters);


### PR DESCRIPTION
## Summary
- reset file input after selecting or parsing a JSON file so users can re-upload the same file

## Testing
- `node --check public/app.js` *(fails: Unexpected token `]`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae70aed58832085a057c835dc914a